### PR TITLE
Return NULL in hidpi_toggle_new if hidpi-daemon not installed

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -11,7 +11,9 @@ pub extern "C" fn hidpi_toggle_new() -> *mut HiDpiToggle {
         gtk::set_initialized();
     }
 
-    Box::into_raw(Box::new(Toggle::new())) as *mut HiDpiToggle
+    Toggle::new().map_or(ptr::null_mut(), |toggle| {
+        Box::into_raw(Box::new(toggle)) as *mut HiDpiToggle
+    })
 }
 
 #[no_mangle]


### PR DESCRIPTION
This, along with a gnome-control-center change, will allow hidpi-daemon to be safely removed