### PR TITLE
Update to gtk-rs 0.9, use shlibs for dependencies, use cdylib-link-lines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [ "ffi", "tools" ]
 
 [dependencies]
 derive_more = "0.99"
-gio = "0.8"
-glib = "0.9"
-gtk = { version = "0.8.0", features = ["v3_22"] }
+gio = "0.9.0"
+glib = "0.10.0"
+gtk = { version = "0.9.0", features = ["v3_22"] }
 gtk-extras = { git = "https://github.com/pop-os/gtk-extras" }

--- a/debian/control
+++ b/debian/control
@@ -15,9 +15,8 @@ Homepage: https://github.com/pop-os/hidpi-widget
 Package: libs76-hidpi-widget
 Architecture: amd64
 Depends:
-  libgtk-3-0,
   ${misc:Depends},
-  ${shlib:Depends}
+  ${shlibs:Depends}
 Description: System76 HiDPI daemon widget library
  Shared library for C which provides the System76 HiDPI daemon widget.
 

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -11,7 +11,7 @@ name = "s76_hidpi_widget"
 crate-type = [ "cdylib" ]
 
 [dependencies]
-glib = "0.9"
-gtk-sys = "0.9"
-gtk = "0.8.0"
+glib = "0.10.0"
+gtk-sys = "0.10.0"
+gtk = "0.9.0"
 hidpi-widget = { path = "../" }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[build-dependencies]
+cdylib-link-lines = "0.1"
+
 [lib]
 name = "s76_hidpi_widget"
 crate-type = [ "cdylib" ]

--- a/ffi/build.rs
+++ b/ffi/build.rs
@@ -1,6 +1,8 @@
 use std::{env, fs::File, io::Write, path::PathBuf};
 
 fn main() {
+    cdylib_link_lines::metabuild();
+
     let target_dir = PathBuf::from("../target");
 
     let pkg_config = format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn main() {
             ..add(&widget);
             ..show_all();
             ..connect_delete_event(move |window, _| {
-                window.destroy();
+                window.close();
 
                 // Allow this closure to attain ownership of our firmware widget,
                 // so that this widget will exist for as long as the window exists.


### PR DESCRIPTION
Using `shlibs` to generate the run-time library dependencies is the correct method in Debian packaging conventions, and is effective at determining what dependencies and versions are needed.

Using `cdylib-link-lines` adds a major version to the library's `SONAME`, which seems to be sufficient to get `dpkg-shlibdeps` to not produce a warning, and successfully output the library dependency.

While I was doing this, I thought I might as well update gtk-rs.