### PR TITLE
fix: Add .shlibs file, and update version to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hidpi-widget"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Michael Aaron Murphy <mmstick@pm.me>"]
 edition = "2018"
 license = "GPLv3"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-hidpi-widget (0.1.1) groovy; urgency=medium
+
+  * Include SONAME in library
+
+ -- Ian Douglas Scott <idscott@system76.com>  Tue, 01 Dec 2020 10:37:06 -0800
+
 system76-hidpi-widget (0.1.0) eoan; urgency=medium
 
   * Initial release. (Closes: #XXXXXX)

--- a/debian/libs76-hidpi-widget.shlibs
+++ b/debian/libs76-hidpi-widget.shlibs
@@ -1,0 +1,1 @@
+libs76_hidpi_widget 0 libs76-hidpi-widget (>= 0.1.1)

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffi"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Michael Aaron Murphy <mmstick@pm.me>"]
 edition = "2018"
 


### PR DESCRIPTION
It seems the gnome-control-center binary ends up linking against the SONAME symlink, so it should depend on a version that includes it. With this, `dh_shlibdeps` generates such a dependency. This, or `.symbols`, is also required by the debian policy manual, so it's probably best to tend to follow the conventions for `.deb` packages.

This should not change the behavior of anything other than new packages built against this library.

Building the 3.38.2 branch of gnome-control-center with `fakeroot make -f debian/rules binary` when this version is installed resulted in a generated dependency with the version requirement from `.shlibs`.