### PR TITLE
fix: Use HdyActionRow from libhandy, and bind GSettings keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,10 @@ members = [ "ffi", "tools" ]
 
 
 [dependencies]
+cascade = "1"
 derive_more = "0.99"
 gio = "0.9.0"
 glib = "0.10.0"
 gtk = { version = "0.9.0", features = ["v3_22"] }
 gtk-extras = { git = "https://github.com/pop-os/gtk-extras" }
+libhandy = "0.7"

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Build-Depends:
   cargo,
   rustc (>=1.36.0),
   libgtk-3-dev,
+  libhandy-1-dev,
   libxml2-dev,
   pkg-config,
 Standards-Version: 4.3.0

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -11,9 +11,8 @@ pub extern "C" fn hidpi_toggle_new() -> *mut HiDpiToggle {
         gtk::set_initialized();
     }
 
-    Toggle::new().map_or(ptr::null_mut(), |toggle| {
-        Box::into_raw(Box::new(toggle)) as *mut HiDpiToggle
-    })
+    Toggle::new()
+        .map_or(ptr::null_mut(), |toggle| Box::into_raw(Box::new(toggle)) as *mut HiDpiToggle)
 }
 
 #[no_mangle]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,12 @@
 #[macro_use]
 extern crate derive_more;
 
+use cascade::cascade;
 use gio::SettingsExt;
-use gtk_extras::{settings, ToggleVariant, VariantToggler};
-
-#[derive(Clone, Copy, Debug)]
-enum HiDpiEvent {
-    /// Defines if the daemon should be enabled.
-    Daemon,
-    /// Defines if LoDPI displays should be rendered at HiDPI resolutions.
-    LoRenderHi,
-}
+use glib::clone;
+use gtk::prelude::*;
+use gtk_extras::settings;
+use libhandy::prelude::*;
 
 #[derive(AsRef, Deref)]
 #[as_ref]
@@ -22,30 +18,54 @@ impl HiDpiToggle {
     pub fn new() -> Option<Self> {
         let settings = settings::new_checked("com.system76.hidpi")?;
 
-        let variants = [
-            ToggleVariant {
-                name:        "Enabled",
-                description: "Enable or disable the HiDPI daemon.",
-                active:      settings.get_boolean("enable"),
-                event:       HiDpiEvent::Daemon,
-            },
-            ToggleVariant {
-                name:        "Mode",
-                description: "Enable to render LoDPI displays at HiDPI resolution.",
-                active:      settings.get_string("mode").map_or(false, |string| string == "hidpi"),
-                event:       HiDpiEvent::LoRenderHi,
-            },
-        ];
+        let enable_switch = cascade! {
+            gtk::Switch::new();
+            ..set_valign(gtk::Align::Center);
+        };
+        let enable_row = cascade! {
+            libhandy::ActionRow::new();
+            ..set_title(Some("Enabled"));
+            ..set_subtitle(Some("Enable or disable the HiDPI daemon."));
+            ..add(&enable_switch);
+        };
+        settings.bind("enable", &enable_switch, "active", gio::SettingsBindFlags::DEFAULT);
 
-        let event_handler = move |event, active| match event {
-            HiDpiEvent::Daemon => {
-                settings.set_boolean("enable", active);
+        let mode_switch = cascade! {
+            gtk::Switch::new();
+            ..set_valign(gtk::Align::Center);
+        };
+        let mode_row = cascade! {
+            libhandy::ActionRow::new();
+            ..set_title(Some("Mode"));
+            ..set_subtitle(Some("Enable to render LoDPI displays at HiDPI resolution."));
+            ..add(&mode_switch);
+        };
+        // TODO: Update once gtk-rs is released with binding for `g_settings_bind_with_mapping`
+        // https://github.com/gtk-rs/gtk-rs/pull/210
+        let value = settings.get_string("mode").map(|s| s == "hidpi").unwrap_or(false);
+        mode_switch.set_active(value);
+        settings.connect_changed(clone!(@weak mode_switch => move |settings, key| {
+            if key == "mode" {
+                let value = settings.get_string("mode").map(|s| s == "hidpi").unwrap_or(false);
+                mode_switch.set_active(value);
             }
-            HiDpiEvent::LoRenderHi => {
-                settings.set_string("mode", if active { "hidpi" } else { "lodpi" });
-            }
+        }));
+        mode_switch.connect_property_active_notify(clone!(@strong settings => move |switch| {
+            let value = if switch.get_active() {
+                "hidpi"
+            } else {
+                "lodpi"
+            };
+            let _ = settings.set_string("mode", value);
+        }));
+
+        let list_box = cascade! {
+            gtk::ListBox::new();
+            ..set_selection_mode(gtk::SelectionMode::None);
+            ..add(&enable_row);
+            ..add(&mode_row);
         };
 
-        Some(Self(VariantToggler::new(&variants, event_handler).into()))
+        Some(Self(list_box.upcast()))
     }
 }


### PR DESCRIPTION
By using `HdyActionRow` like other parts of gnome-control-center, including in the same panel, this fixes the visual inconsistency mentioned in https://github.com/pop-os/hidpi-widget/issues/6.

By watching for changes to the GSettings keys, the switches show when another application changes the value of the key. It seems the when hidpidaemon shows a dialog and the user selects "stay in LoDPI", it changes the GSettings value back. So this should be sufficient to fix https://github.com/pop-os/hidpi-widget/issues/5.

Hopefully a future version of gtk-rs will make it possible to improve the uglier part of this code.

This won't build on bionic, which lacks `libhandy-1`. That shouldn't be a problem since hidpi-widget isn't used by the bionic package for gnome-control-center.