### PR TITLE
Add arm64 builds

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Standards-Version: 4.3.0
 Homepage: https://github.com/pop-os/hidpi-widget
 
 Package: libs76-hidpi-widget
-Architecture: amd64
+Architecture: amd64 arm64
 Depends:
   ${misc:Depends},
   ${shlibs:Depends}


### PR DESCRIPTION
Required for building gnome-control-center